### PR TITLE
Misc Fixes to Pass `make`

### DIFF
--- a/src/bam_region.cpp
+++ b/src/bam_region.cpp
@@ -98,7 +98,7 @@ long unsigned int Bam_Region::compute_num_paths()
 	return num_paths;
 }
 
-void Bam_Region::write_segment_graph(_IO_FILE*& fd)
+void Bam_Region::write_segment_graph(FILE*& fd)
 {
 	fprintf(fd, "region\t%s\t%c\t%i\t%i\n", chr, strand, start, stop);
 
@@ -1037,7 +1037,7 @@ void Bam_Region::add_bias_counts(vector<int>* vec)
 
 }
 
-void Bam_Region::print_segments_and_coverage(_IO_FILE*& fd)
+void Bam_Region::print_segments_and_coverage(FILE*& fd)
 {
 	for (uint i=0; i<segments.size(); i++) 
 	{
@@ -1964,7 +1964,7 @@ int Bam_Region::read_binary(std::ifstream* ifs)
 	// splice graph
 	ifs->read((char *) &len, sizeof(int));
 	assert(len>0);
-	segment seg[len];
+        segment *seg = new segment[len];
 	ifs->read((char *) seg, len*sizeof(segment));
 	for (int i=0; i<len; i++)
 	{

--- a/src/bam_region.h
+++ b/src/bam_region.h
@@ -85,7 +85,7 @@ class Bam_Region: public Region
 		int get_read_ends(int from, int to);
 
 		void find_tss_and_cleave(vector<int>* pos, vector<int>* starts, vector<int>* stops, float pval);
-		void write_segment_graph(_IO_FILE*& fd);
+		void write_segment_graph(FILE*& fd);
 
 		void generate_segment_graph(float seg_filter, float tss_pval);
 
@@ -101,7 +101,7 @@ class Bam_Region: public Region
 
 		vector<int> get_children(int node, bool no_neighbors);
 
-		void print_segments_and_coverage(_IO_FILE*& fd);
+		void print_segments_and_coverage(FILE*& fd);
 
 };
 #endif

--- a/src/configure
+++ b/src/configure
@@ -345,7 +345,7 @@ if [ "$USE_GLPK" == "yes" ]; then
 	echo "INCLUDE_DIRS += $GLPK_INCL" >> Makefile
 	echo "LD_DIRS += $GLPK_LD" >> Makefile
 	echo "LIBS += $GLPK_LIBS" >> Makefile
-	echo "GLPK = solve_lp_glpk.cpp -lglpk" >> Makefile
+	echo "GLPK = solve_lp_glpk.cpp" >> Makefile
 	echo  >> Makefile
 fi
 if [ "$USE_CPLEX" == "yes" ]; then

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -386,7 +386,7 @@ void Region::load_genomic_sequence()
 	seq = gio->read_flat_file(chr_num, start-1, stop-1);
 }
 
-void Region::print(_IO_FILE*& fd)
+void Region::print(FILE*& fd)
 {
 	fprintf(fd, "region %s\n", get_region_str());
 	fprintf(fd, "region start:\t%i\n", start);

--- a/src/region.h
+++ b/src/region.h
@@ -112,7 +112,7 @@ class Region
 
 		char* get_region_str();
 
-		virtual void print(_IO_FILE*& fd);
+		virtual void print(FILE*& fd);
 
 	private: 
 		char* seq;

--- a/src/tools/genome/genome_tools.cpp
+++ b/src/tools/genome/genome_tools.cpp
@@ -13,7 +13,7 @@ void save_score_pos(char* path_prefix, char** score_names, float** scores, int n
 	
 	// open output files
 	char filename[MAXLINE]; 
-	fstream score_fds[num_scores];
+	fstream *score_fds = new fstream[num_scores];
 	fstream pos_fd; 
     sprintf(filename, "%s.pos", path_prefix);
     pos_fd.open(filename, fstream::out);


### PR DESCRIPTION
The included changes fixed multiple errors that I was running into during `make` (including the one described in Issue #3).

The following changes were made:
* `_IO_FILE` types changed to `FILE` type in `bam_region.cpp` and `region.cpp`
* Array initialization changed in `bam_region.cpp` and `genome_tools.cpp`. Previously returned `Variable length array of non-POD element type` errors
* `-lglpk` flag removed from `GLPK =` specification in `configure`. Previously caused error during `make` since `$GLPK` is used as a target file and `-lglpk` is not a valid target file.

After these changes, `make` passed with no errors on OSX 10.11.6 with following compiler.
```
$  c++ --version
Apple LLVM version 7.3.0 (clang-703.0.29)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

If these changes seem unnecessary/incorrect, please let me know! 